### PR TITLE
refresh _labelController after _handleControllerChanged

### DIFF
--- a/lib/select_form_field.dart
+++ b/lib/select_form_field.dart
@@ -517,6 +517,21 @@ class _SelectFormFieldState extends FormFieldState<String> {
 
   void _handleControllerChanged() {
     if (_effectiveController?.text != value) {
+      _item = widget.items?.firstWhere(
+        (lmItem) => lmItem['value'].toString() == _effectiveController?.text,
+        orElse: () => <String, dynamic>{},
+      );
+
+      if (_item!.length > 0) {
+        _labelController.text =
+            _item!['label']?.toString() ?? _item!['value']!.toString();
+
+        if (widget.changeIcon &&
+            _item?['icon'] != null &&
+            _item?['icon'] != '') {
+          _icon = _item?['icon'];
+        }
+      }
       didChange(_effectiveController?.text);
     }
   }


### PR DESCRIPTION
If the SelectFromField text value is changed by code with a controller, it doesn't reflect the new value in the TextField. This happens because _labelController isn't updated.
_labelController must updated on _handleControllerChanged().
